### PR TITLE
achieve the postinstall with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Mantis Bug Tracker is a free and open source, web-based bug tracking system. The
 ## Documentation
 
  * Official documentation: https://mantisbt.org/documentation.php
- * YunoHost documentation: If specific documentation is needed, feel free to contribute.
+ * YunoHost documentation: https://yunohost.org/#/app_mantis
 
 ## YunoHost specific features
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -32,7 +32,7 @@ Mantis Bug Tracker est un système de suivi des bogues gratuit et open source. L
 ## Documentation
 
  * Documentation officielle : https://mantisbt.org/documentation.php
- * Documentation YunoHost : Si une documentation spécifique est nécessaire, n'hésitez pas à contribuer.
+ * Documentation YunoHost :  https://yunohost.org/#/app_mantis_fr
 
 ## Caractéristiques spécifiques YunoHost
 

--- a/scripts/install
+++ b/scripts/install
@@ -130,7 +130,7 @@ ynh_systemd_action --service_name=nginx --action=reload
 ynh_script_progression --message="Finalizing installation..." --weight=10
 
 # Installation with curl
-installUrl="/admin/install.php"
+installUrl="/admin/install.php?submit"
 
 ynh_local_curl $installUrl "install=2" "db_type=mysqli" "hostname=localhost" "db_username=$db_user" "db_password=$db_pwd" "database_name=$db_name" "admin_username=" "admin_password=" "db_table_prefix=$db_name" "db_table_plugin_prefix=plugin" "db_table_suffix=_table" "timezone=UTC"
 

--- a/scripts/install
+++ b/scripts/install
@@ -119,14 +119,30 @@ chown -R www-data:www-data $final_path
 chmod -R 755 $final_path
 
 #=================================================
+# SETUP APPLICATION WITH CURL
+#=================================================
+# Set the app as temporarily public for curl call
+ynh_permission_update --permission "main" --add "visitors"
+
+# Reload Nginx
+ynh_systemd_action --service_name=nginx --action=reload
+
+ynh_script_progression --message="Finalizing installation..." --weight=10
+
+# Installation with curl
+installUrl="/admin/install.php"
+
+ynh_local_curl $installUrl "install=2" "db_type=mysqli" "hostname=localhost" "db_username=$db_user" "db_password=$db_pwd" "database_name=$db_name" "admin_username=" "admin_password=" "db_table_prefix=$db_name" "db_table_plugin_prefix=plugin" "db_table_suffix=_table" "timezone=UTC"
+
+#=================================================
 # SETUP SSOWAT
 #=================================================
 ynh_script_progression --message="Configuring SSOwat..." --weight=1
 
 # Make app public if necessary or protect it
-if [ $is_public -eq 1 ]
+if [ $is_public -eq 0 ]
 then
-	ynh_permission_update --permission "main" --add "visitors"
+	ynh_permission_update --permission "main" --remove "visitors"
 fi
 
 #=================================================


### PR DESCRIPTION
To achieve a postinstall with curl  you must visit the corresponding install page (here `/admin/install.php`), then inspect the elements of the form to be filled in:

![image](https://user-images.githubusercontent.com/3713691/99951101-d43f1d00-2d7d-11eb-986a-860ad7061a46.png)

And for each element of the form, translate it to a parameter of `ynh_local_curl`
![image](https://user-images.githubusercontent.com/3713691/99951225-0486bb80-2d7e-11eb-94ae-c85194084300.png)

For example here, the select with the id `db_type` takes the value `mysqli`.

Do that for ALL fields, and then you can try do use the helper in your terminal:

```bash
source /usr/share/yunohost/helpers
installUrl="/admin/install.php?submit" # ?submit is the name of the button you must click in your browser

# required by ynh_local_curl helper
domain=the_mantis_domain
path_url=/the_path_url_of_mantis

db_user=mantis
db_pwd=randomstring
db_name=$db_user
# etc

 ynh_local_curl $installUrl "db_type=mysqli" "hostname=localhost" "db_username=$db_user" "db_password=$db_pwd" "database_name=$db_name" "admin_username=" "admin_password=" "db_table_prefix=$db_name" "db_table_plugin_prefix=plugin" "db_table_suffix=_table" "timezone=UTC"
```

Et voilà! (don't forget to put your app public for the curl, and remove `visitors` group if needed.)

....
....
....

Wait, no it doesn't works, wtf!

Ha yeah, sometimes, there is hidden fields, here `install` with the value `2`:
![image](https://user-images.githubusercontent.com/3713691/99951905-187eed00-2d7f-11eb-8be2-faea72532297.png)
